### PR TITLE
Stringify log objects

### DIFF
--- a/jQuery.clientSideLogging.js
+++ b/jQuery.clientSideLogging.js
@@ -73,4 +73,24 @@
 
 		return _info;
 	};
+
+	// Fallback for older browsers that don't implement JSON.stringify
+	JSON.stringify = JSON.stringify || function (obj) {
+		var t = typeof (obj);
+		if (t != "object" || obj === null) {
+			// simple data type
+			if (t == "string") obj = '"'+obj+'"';
+			return String(obj);
+		} else {
+			// recurse array or object
+			var n, v, json = [], arr = (obj && obj.constructor == Array);
+			for (n in obj) {
+				v = obj[n]; t = typeof(v);
+				if (t == "string") v = '"'+v+'"';
+				else if (t == "object" && v !== null) v = JSON.stringify(v);
+				json.push((arr ? "" : '"' + n + '":') + String(v));
+			}
+			return (arr ? "[" : "{") + String(json) + (arr ? "]" : "}");
+		}
+	};
 })(jQuery);


### PR DESCRIPTION
When you log an object, the code currently sends the object's properties to the backend as an glob of POST variables. Since the objects that can be logged are entirely arbitrary, this means that the backend has to cope with arbitrary numbers of values, with arbitrary keys.

It's simpler to simply pass them along in "msg" as we would a text log, but encode them as JSON; that way the backend can either log them straight as JSON (since it's already a serialised data store) or decode the JSON and do what it wants with them.
