### PR TITLE
Actually apply options that are passed to .clientSideLogging.

### DIFF
--- a/jQuery.clientSideLogging.js
+++ b/jQuery.clientSideLogging.js
@@ -30,7 +30,7 @@
 	* @param  options The custom options.
 	*/
 	$.clientSideLogging = function(options) {
-		$.extend(defaults, options || {});
+		defaults = $.extend(defaults, options || {});
 	};
 
    /**


### PR DESCRIPTION
Currently, options passed to clientSideLogging aren't actually used; arguments to `jQuery.extend` aren't passed by reference, the array returned by it has to be used. This fixes that.
